### PR TITLE
Fix README where Python 3 is supported

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Installation
 
 To install ``shortuuid`` you need:
 
-* Python 2.5 or later in the 2.x line (3.x not supported, earlier than 2.5 not tested).
+* Python 2.5 or later in the 2.x line (earlier than 2.5 not tested).
 
 If you have the dependencies, you have multiple options of installation:
 


### PR DESCRIPTION
The README file says Python 3 is not supported while according to travis it seems it is.
