### PR TITLE
Append copying to MANIFEST.in, because of violating BSD-3

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include MANIFEST.in
+include COPYING
+include README.rst
+recursive-include shortuuid *.py


### PR DESCRIPTION
Hi,

I want to append 'COPYING' file to MANIFEST.in file.

'shortuuid' is licensed with the BSD 3-Clause license in COPYING.
But tarball distributed in PyPI does not have COPYING file.

I intend to Debian package(*), but this package has been rejected by above reason.
So I request to merge this patch.

And so I want that you update latest version to GitHub reposity. :)

Best regards,
- http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=717542

Signed-off-by: Kouhei Maeda mkouhei@palmtb.net
