### PR TITLE
Adding missing characters to the alphabet

### DIFF
--- a/shortuuid/main.py
+++ b/shortuuid/main.py
@@ -9,8 +9,8 @@ import uuid as _uu
 class ShortUUID(object):
     def __init__(self, alphabet=None):
         if alphabet is None:
-            alphabet = list("23456789ABCDEFGHJKLMNPQRSTUVWXYZ"
-                            "abcdefghijkmnopqrstuvwxyz")
+            alphabet = list("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                            "abcdefghijklmnopqrstuvwxyz")
         # Define our alphabet.
         self._alphabet = alphabet
         self._alpha_len = len(self._alphabet)

--- a/shortuuid/tests.py
+++ b/shortuuid/tests.py
@@ -19,11 +19,11 @@ class LegacyShortUUIDTest(unittest.TestCase):
 
     def test_encoding(self):
         u = UUID('{12345678-1234-5678-1234-567812345678}')
-        self.assertEqual(encode(u), "VoVuUtBhZ6TvQSAYEqNdF5")
+        self.assertEqual(encode(u), "APIH05RRfpiawN2WWNmLY")
 
     def test_decoding(self):
         u = UUID('{12345678-1234-5678-1234-567812345678}')
-        self.assertEqual(decode("VoVuUtBhZ6TvQSAYEqNdF5"), u)
+        self.assertEqual(decode("APIH05RRfpiawN2WWNmLY"), u)
 
     def test_alphabet(self):
         backup_alphabet = get_alphabet()
@@ -66,12 +66,12 @@ class ClassShortUUIDTest(unittest.TestCase):
     def test_encoding(self):
         su = ShortUUID()
         u = UUID('{12345678-1234-5678-1234-567812345678}')
-        self.assertEqual(su.encode(u), "VoVuUtBhZ6TvQSAYEqNdF5")
+        self.assertEqual(su.encode(u), "APIH05RRfpiawN2WWNmLY")
 
     def test_decoding(self):
         su = ShortUUID()
         u = UUID('{12345678-1234-5678-1234-567812345678}')
-        self.assertEqual(su.decode("VoVuUtBhZ6TvQSAYEqNdF5"), u)
+        self.assertEqual(su.decode("APIH05RRfpiawN2WWNmLY"), u)
 
     def test_random(self):
         su = ShortUUID()


### PR DESCRIPTION
There are some characters missing from the default alphabet.  This
may have been intentional since the characters look alike, but
it limits the ability for you to create your own alphabet with
those letters since they must be in that original list.
