### PR TITLE
Change docs for correct usage of random

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ resulting UUID:
 You can also generate a cryptographically secure random string (using 
 `os.urandom()`, internally) with:
 
->>> shortuuid.random(length=22)
+>>> shortuuid.ShortUUID().random(length=22)
 'RaF56o2r58hTKT7AYS9doj'
 
 


### PR DESCRIPTION
This is how random is used in the tests. I'm guessing it isn't imported in `__init__.py` so that it doesn't collide with python core lib `random`.
