### PR TITLE
Added basic input type validation to encode and decode

### DIFF
--- a/shortuuid/main.py
+++ b/shortuuid/main.py
@@ -54,6 +54,8 @@ class ShortUUID(object):
 
         If leftmost (MSB) bits are 0, the string might be shorter.
         """
+        if not isinstance(uuid, _uu.UUID):
+            raise ValueError('Input `uuid` must be a UUID object.')
         if pad_length is None:
             pad_length = self._length
         return int_to_string(uuid.int, self._alphabet, padding=pad_length)
@@ -69,6 +71,8 @@ class ShortUUID(object):
         Pass `legacy=True` if your UUID was encoded with a ShortUUID version
         prior to 1.0.0.
         """
+        if not isinstance(string, str):
+            raise ValueError('Input `string` must be a str.')
         if legacy:
             string = string[::-1]
         return _uu.UUID(int=string_to_int(string, self._alphabet))

--- a/shortuuid/main.py
+++ b/shortuuid/main.py
@@ -55,7 +55,7 @@ class ShortUUID(object):
         If leftmost (MSB) bits are 0, the string might be shorter.
         """
         if not isinstance(uuid, _uu.UUID):
-            raise ValueError('Input `uuid` must be a UUID object.')
+            raise ValueError("Input `uuid` must be a UUID object.")
         if pad_length is None:
             pad_length = self._length
         return int_to_string(uuid.int, self._alphabet, padding=pad_length)
@@ -72,7 +72,7 @@ class ShortUUID(object):
         prior to 1.0.0.
         """
         if not isinstance(string, str):
-            raise ValueError('Input `string` must be a str.')
+            raise ValueError("Input `string` must be a str.")
         if legacy:
             string = string[::-1]
         return _uu.UUID(int=string_to_int(string, self._alphabet))

--- a/shortuuid/tests.py
+++ b/shortuuid/tests.py
@@ -172,7 +172,6 @@ class ShortUUIDPaddingTest(unittest.TestCase):
 
 
 class EncodingEdgeCasesTest(unittest.TestCase):
-
     def test_decode_dict(self):
         su = ShortUUID()
         self.assertRaises(ValueError, su.encode, [])
@@ -181,8 +180,8 @@ class EncodingEdgeCasesTest(unittest.TestCase):
         self.assertRaises(ValueError, su.encode, 42)
         self.assertRaises(ValueError, su.encode, 42.0)
 
-class DecodingEdgeCasesTest(unittest.TestCase):
 
+class DecodingEdgeCasesTest(unittest.TestCase):
     def test_decode_dict(self):
         su = ShortUUID()
         self.assertRaises(ValueError, su.decode, [])

--- a/shortuuid/tests.py
+++ b/shortuuid/tests.py
@@ -171,5 +171,26 @@ class ShortUUIDPaddingTest(unittest.TestCase):
         self.assertEqual(uid_lengths[uid_length], num_iterations)
 
 
+class EncodingEdgeCasesTest(unittest.TestCase):
+
+    def test_decode_dict(self):
+        su = ShortUUID()
+        self.assertRaises(ValueError, su.encode, [])
+        self.assertRaises(ValueError, su.encode, {})
+        self.assertRaises(ValueError, su.decode, (2,))
+        self.assertRaises(ValueError, su.encode, 42)
+        self.assertRaises(ValueError, su.encode, 42.0)
+
+class DecodingEdgeCasesTest(unittest.TestCase):
+
+    def test_decode_dict(self):
+        su = ShortUUID()
+        self.assertRaises(ValueError, su.decode, [])
+        self.assertRaises(ValueError, su.decode, {})
+        self.assertRaises(ValueError, su.decode, (2,))
+        self.assertRaises(ValueError, su.decode, 42)
+        self.assertRaises(ValueError, su.decode, 42.0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
While working on a `ShortUUIDField` for django, I notice empty list `[]` gets decoded as `uuid.UUID('00000000-0000-0000-0000-000000000000')` which is unexpected, so added some input type-checks.