### PR TITLE
Fix compatibility for python versions older than 3.8

### DIFF
--- a/shortuuid/__init__.py
+++ b/shortuuid/__init__.py
@@ -1,6 +1,4 @@
 # flake8: noqa
-import importlib.metadata
-
 from shortuuid.main import decode
 from shortuuid.main import encode
 from shortuuid.main import get_alphabet


### PR DESCRIPTION
Removed `importlib.metadata` import as it's not used anymore and breaks compatibility with older python versions. Fixes #60