### PR TITLE
Issue #82: Make ShortUUIDField generate actual valid uuid when length parameter not provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ class MyModel(models.Model):
         alphabet="abcdefg1234",
         primary_key=True,
     )
-    # When ShortUUIDField is provided with a length parameter, a cryptographically secure but 
-    # NOT universally unique string is generated
+    # When ShortUUIDField is provided with a length parameter, a cryptographically secure 
+    # random but NOT universally unique string is generated
     random_field = ShortUUIDField(
         length=16,
         max_length=40,
@@ -178,7 +178,7 @@ class MyModel(models.Model):
         primary_key=True,
     )
 
-    # A short random cryptographically secure string of length 22 and the default alphabet.
+    # A short cryptographically secure random string of length 22 and the default alphabet.
     api_key = ShortUUIDField(length=22) 
 ```
 

--- a/README.md
+++ b/README.md
@@ -160,8 +160,17 @@ your convenience:
 from shortuuid.django_fields import ShortUUIDField
 
 class MyModel(models.Model):
-    # A primary key ID of length 16 and a short alphabet.
+    # A primary key ID with a short alphabet.
+    # When ShortUUIDField is not provided with length, a uuid is generated
     id = ShortUUIDField(
+        max_length=40,
+        prefix="id_",
+        alphabet="abcdefg1234",
+        primary_key=True,
+    )
+    # When ShortUUIDField is provided with a length parameter, a cryptographically secure but 
+    # NOT universally unique string is generated
+    random_field = ShortUUIDField(
         length=16,
         max_length=40,
         prefix="id_",
@@ -169,13 +178,21 @@ class MyModel(models.Model):
         primary_key=True,
     )
 
-    # A short UUID of length 22 and the default alphabet.
-    api_key = ShortUUIDField()
+    # A short random cryptographically secure string of length 22 and the default alphabet.
+    api_key = ShortUUIDField(length=22) 
 ```
 
 The field is the same as the `CharField`, with a `length` argument (the length of the
-ID), an `alphabet` argument, and the `default` argument removed. Everything else is
-exactly the same, e.g. `index`, `help_text`, `max_length`, etc.
+ID for cryptographically secure random strings), an `alphabet` argument, and the `default` 
+argument removed. Everything else is exactly the same, e.g. `index`, `help_text`, `max_length`, 
+etc.
+
+If you do not provide a `length` parameter, the field will generate a default value using
+`ShortUUID.uuid` which will be universally unique.
+
+However, if you provide a `length` paramter, the field will genrate a default value using
+`ShortUUID.random` which WILL NOT BE universally unique.
+
 
 
 Compatibility note

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ etc.
 If you do not provide a `length` parameter, the field will generate a default value using
 `ShortUUID.uuid` which will be universally unique.
 
-However, if you provide a `length` paramter, the field will genrate a default value using
+However, if you provide a `length` parameter, the field will genrate a default value using
 `ShortUUID.random` which WILL NOT BE universally unique.
 
 

--- a/shortuuid/django_fields.py
+++ b/shortuuid/django_fields.py
@@ -7,26 +7,57 @@ from typing import Any, Dict, Tuple
 
 
 class ShortUUIDField(models.CharField):
-    description = _("A short UUID field.")
+    description = _("A short UUID field. Without a length parameter, generates a short UUID.  Providing a length, only generates "
+    "a random string of the provided length. Not guaranteed universally unique.")
 
     def __init__(self, *args: Tuple, **kwargs: Dict[str, Any]) -> None:
-        self.length = kwargs.pop("length", 22)
+        """If called without a `length` parameter, generates a `ShortUUID` for the default value.  Guaranteed universally unique.
+        Length of the UUID is based on the size of the provided alphabet
+
+        If the `length` parameter is provided, generates a cryptographically secure random string of that length (using os.urandom() internally).
+        WARNING: This is NOT guaranteed to be universally unique as it is not a UUID, soley a random string.
+        """
+        self.length = kwargs.pop("length", None)
         self.prefix = kwargs.pop("prefix", "")
-
-        if "max_length" not in kwargs:
-            # If `max_length` was not specified, set it here.
-            kwargs["max_length"] = self.length + len(self.prefix)
-
         self.alphabet = kwargs.pop("alphabet", None)
-        kwargs["default"] = self._generate_uuid
+
+        if self.length is None:  # Generate a UUID
+            required_length = self._shortuuid._length + len(self.prefix)
+            if "max_length" in kwargs and kwargs["max_length"] < required_length:
+                raise Exception(f"max_length too small to fit generated UUID of length {required_length} (including prefix)")
+            if "max_length" not in kwargs:
+                kwargs["max_length"] = required_length
+
+            kwargs["default"] = self._generate_uuid
+        else:  # User provided length, generate a random but not universally unique string
+            required_length = self.length + len(self.prefix)
+            if "max_length" not in kwargs:
+                # If `max_length` was not specified, set it here.
+                kwargs["max_length"] = required_length
+            elif "max_length" in kwargs and kwargs["max_length"] < required_length:
+                raise Exception(f"max_length too small to fit generated random of length {required_length} (including prefix)")
+
+            kwargs["default"] = self._generate_random
 
         super().__init__(*args, **kwargs)
 
-    def _generate_uuid(self) -> str:
-        """Generate a short random string."""
-        return self.prefix + ShortUUID(alphabet=self.alphabet).random(
+    def _generate_random(self) -> str:
+        """Generate a cryptographically secure random string (using os.urandom() internally)
+        WARNING: This is NOT guaranteed to be universally unique as it is not a UUID, soley a cryptographically secure random string.
+        """
+        return self.prefix + self._shortuuid.random(
             length=self.length
         )
+
+    def _generate_uuid(self) -> str:
+        """Generate a uuid"""
+        return self.prefix + self._shortuuid.uuid()
+
+    @property
+    def _shortuuid(self) -> ShortUUID:
+        if not hasattr(self, "__shortuuid"):
+            self.__shortuuid = ShortUUID(alphabet=self.alphabet)
+        return self.__shortuuid
 
     def deconstruct(self) -> Tuple[str, str, Tuple, Dict[str, Any]]:
         name, path, args, kwargs = super().deconstruct()


### PR DESCRIPTION
Previously, this field only generated a cryptographically secure random string as the default value.  Now, if no length parameter is provided, the field will generate a valid uuid decodable string.

Update readme with new information on field usage

Pull request for #82 