### PR TITLE
add py.typed to MANIFEST.in, re-export API

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include MANIFEST.in
 include COPYING
 include README.rst
-recursive-include shortuuid *.py
+recursive-include shortuuid *.py py.typed

--- a/shortuuid/__init__.py
+++ b/shortuuid/__init__.py
@@ -8,11 +8,11 @@ from shortuuid.main import uuid
 
 __version__ = "1.0.10"
 __all__ = [
-    "decode", 
-    "encode", 
-    "get_alphabet", 
-    "random", 
-    "set_alphabet", 
-    "ShortUUID", 
+    "decode",
+    "encode",
+    "get_alphabet",
+    "random",
+    "set_alphabet",
+    "ShortUUID",
     "uuid",
 ]

--- a/shortuuid/__init__.py
+++ b/shortuuid/__init__.py
@@ -8,11 +8,11 @@ from shortuuid.main import uuid
 
 __version__ = "1.0.10"
 __all__ = [
-  "decode", 
-  "encode", 
-  "get_alphabet", 
-  "random", 
-  "set_alphabet", 
-  "ShortUUID", 
-  "uuid",
+    "decode", 
+    "encode", 
+    "get_alphabet", 
+    "random", 
+    "set_alphabet", 
+    "ShortUUID", 
+    "uuid",
 ]

--- a/shortuuid/__init__.py
+++ b/shortuuid/__init__.py
@@ -1,9 +1,12 @@
-from shortuuid.main import decode  # noqa
-from shortuuid.main import encode  # noqa
-from shortuuid.main import get_alphabet  # noqa
-from shortuuid.main import random  # noqa
-from shortuuid.main import set_alphabet  # noqa
-from shortuuid.main import ShortUUID  # noqa
-from shortuuid.main import uuid  # noqa
+from shortuuid.main import decode
+from shortuuid.main import encode
+from shortuuid.main import get_alphabet
+from shortuuid.main import random
+from shortuuid.main import set_alphabet
+from shortuuid.main import ShortUUID
+from shortuuid.main import uuid
 
 __version__ = "1.0.10"
+__all__ = [
+  "decode", "encode", "get_alphabet", "random", "set_alphabet", "ShortUUID", "uuid"
+]

--- a/shortuuid/__init__.py
+++ b/shortuuid/__init__.py
@@ -8,5 +8,11 @@ from shortuuid.main import uuid
 
 __version__ = "1.0.10"
 __all__ = [
-  "decode", "encode", "get_alphabet", "random", "set_alphabet", "ShortUUID", "uuid"
+  "decode", 
+  "encode", 
+  "get_alphabet", 
+  "random", 
+  "set_alphabet", 
+  "ShortUUID", 
+  "uuid",
 ]


### PR DESCRIPTION
Thanks for `shortuuid`!

This PR:
- [x] updates `MANIFEST.in` so that the `py.typed` file is included in the sdist on PyPI, useful for downstream re-builders.
- [x] populates `__all__` in `__init__.py` to avoid some `mypy` warnings
  - [x] allows removing the `noqa` comments