### PR TITLE
Use the SPDX identifier to reference the license

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "shortuuid"
 version = "1.0.11"
 description = "A generator library for concise, unambiguous and URL-safe UUIDs."
-license = "License :: OSI Approved :: BSD License"
+license = "BSD-3-Clause"
 classifiers = [
   "License :: OSI Approved :: BSD License",
   "Programming Language :: Python",


### PR DESCRIPTION
See https://opensource.org/licenses/BSD-3-Clause

This is a more globally accepted way of labeling a project with its license. The "classifiers" format should be reserved for the "classifiers" section of package metadata.

Refs #79