### PR TITLE
Change the type-hints for ShortUUIDField

### DIFF
--- a/shortuuid/django_fields.py
+++ b/shortuuid/django_fields.py
@@ -11,7 +11,7 @@ from . import ShortUUID
 class ShortUUIDField(models.CharField):
     description = _("A short UUID field.")
 
-    def __init__(self, *args: Tuple, **kwargs: Dict[str, Any]) -> None:
+    def __init__(self, *args: Tuple, **kwargs: Any) -> None:
         self.length: int = kwargs.pop("length", 22)  # type: ignore
         self.prefix: str = kwargs.pop("prefix", "")  # type: ignore
 


### PR DESCRIPTION
Change the type-hints for the **kwargs arguments in the ShortUUIDField class so that mypy no longer throws an error about the incompatible type of the arguments passed. As in the following example:
``` python
id = ShortUUIDField(primary_key=True, length=8, max_length=8)
Argument "primary_key" to "ShortUUIDField" has incompatible type "bool"; expected "Dict[str, Any]"  [arg-type]mypy(error)
```