### PR TITLE
fix: annotate *args as Any

### DIFF
--- a/shortuuid/django_fields.py
+++ b/shortuuid/django_fields.py
@@ -11,7 +11,7 @@ from . import ShortUUID
 class ShortUUIDField(models.CharField):
     description = _("A short UUID field.")
 
-    def __init__(self, *args: Tuple, **kwargs: Any) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.length: int = kwargs.pop("length", 22)  # type: ignore
         self.prefix: str = kwargs.pop("prefix", "")  # type: ignore
 


### PR DESCRIPTION
Field `*args` should be typed as `Any`, not tuple. See 
1. [django-types](https://github.com/sbdchd/django-types/blob/main/django-stubs/db/models/fields/__init__.pyi#L124) 
2. [PEP-484](https://peps.python.org/pep-0484/#arbitrary-argument-lists-and-default-argument-values)