### PR TITLE
Don't install COPYING at top level of wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,9 @@ classifiers = [
 homepage = "https://github.com/skorokithakis/shortuuid/"
 authors = ["Stavros Korokithakis <hi@stavros.io>"]
 readme = "README.md"
-include = ["COPYING"]
+include = [
+  { path = "COPYING", format = "sdist" }
+]
 
 [tool.poetry.scripts]
 shortuuid = "shortuuid.cli:cli"


### PR DESCRIPTION
Telling Poetry to install the `COPYING` file without qualification causes it to install that file at the very top level of the wheel, outside the `shortuuid/` directory, and thus to potentially clash with other packages.

We only need to explicitly install it in the sdist.  The wheel still ends up with a copy of the file in `shortuuid-*.dist-info/COPYING`, so no information is lost.