### PR TITLE
feat: Allow compatibility with other ShortUUID libraries (#104)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,16 @@ consistency:
 '0123abcdefgh'
 ```
 
+You can prevent the alphabet from being sorted by passing the `dont_sort_alphabet` 
+keyword argument to `set_alphabet()`. This option ensures compatibility with different 
+implementations of ShortUUID:
+
+```python
+>>> shortuuid.set_alphabet("aaaaabcdefgh1230123", dont_sort_alphabet=True)
+>>> shortuuid.get_alphabet()
+'abcdefgh1230'
+```
+
 If the default 22 digits are too long for you, you can get shorter IDs by just
 truncating the string to the desired length. The IDs won't be universally unique any
 longer, but the probability of a collision will still be very low.
@@ -168,6 +178,7 @@ class MyModel(models.Model):
         max_length=40,
         prefix="id_",
         alphabet="abcdefg1234",
+        dont_sort_alphabet=False
         primary_key=True,
     )
 

--- a/shortuuid/django_fields.py
+++ b/shortuuid/django_fields.py
@@ -14,6 +14,7 @@ class ShortUUIDField(models.CharField):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.length: int = kwargs.pop("length", 22)  # type: ignore
         self.prefix: str = kwargs.pop("prefix", "")  # type: ignore
+        self.sorted: bool = kwargs.pop("should_sort", True)  # type: ignore
 
         if "max_length" not in kwargs:
             # If `max_length` was not specified, set it here.
@@ -26,7 +27,7 @@ class ShortUUIDField(models.CharField):
 
     def _generate_uuid(self) -> str:
         """Generate a short random string."""
-        return self.prefix + ShortUUID(alphabet=self.alphabet).random(
+        return self.prefix + ShortUUID(alphabet=self.alphabet, should_sort=self.sorted).random(
             length=self.length
         )
 

--- a/shortuuid/django_fields.py
+++ b/shortuuid/django_fields.py
@@ -14,7 +14,7 @@ class ShortUUIDField(models.CharField):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.length: int = kwargs.pop("length", 22)  # type: ignore
         self.prefix: str = kwargs.pop("prefix", "")  # type: ignore
-        self.sorted: bool = kwargs.pop("should_sort", True)  # type: ignore
+        self.dont_sort_alphabet: bool = kwargs.pop("dont_sort_alphabet", False)  # type: ignore
 
         if "max_length" not in kwargs:
             # If `max_length` was not specified, set it here.
@@ -27,7 +27,7 @@ class ShortUUIDField(models.CharField):
 
     def _generate_uuid(self) -> str:
         """Generate a short random string."""
-        return self.prefix + ShortUUID(alphabet=self.alphabet, should_sort=self.sorted).random(
+        return self.prefix + ShortUUID(alphabet=self.alphabet, dont_sort_alphabet=self.dont_sort_alphabet).random(
             length=self.length
         )
 

--- a/shortuuid/main.py
+++ b/shortuuid/main.py
@@ -40,11 +40,11 @@ def string_to_int(string: str, alphabet: List[str]) -> int:
 
 
 class ShortUUID(object):
-    def __init__(self, alphabet: Optional[str] = None, should_sort: Optional[bool] = True) -> None:
+    def __init__(self, alphabet: Optional[str] = None, dont_sort_alphabet: Optional[bool] = False) -> None:
         if alphabet is None:
             alphabet = "23456789ABCDEFGHJKLMNPQRSTUVWXYZ" "abcdefghijkmnopqrstuvwxyz"
 
-        self.set_alphabet(alphabet, should_sort=should_sort)
+        self.set_alphabet(alphabet, dont_sort_alphabet=dont_sort_alphabet)
 
     @property
     def _length(self) -> int:
@@ -110,11 +110,11 @@ class ShortUUID(object):
         """Return the current alphabet used for new UUIDs."""
         return "".join(self._alphabet)
 
-    def set_alphabet(self, alphabet: str, should_sort: bool=True) -> None:
+    def set_alphabet(self, alphabet: str, dont_sort_alphabet: bool=False) -> None:
         """Set the alphabet to be used for new UUIDs."""
         # Turn the alphabet into a set and sort it to prevent duplicates
         # and ensure reproducibility.
-        new_alphabet = list(sorted(set(alphabet)) if should_sort else list(dict.fromkeys(alphabet)))
+        new_alphabet = list(dict.fromkeys(alphabet)) if dont_sort_alphabet else list(sorted(set(alphabet)))
         if len(new_alphabet) > 1:
             self._alphabet = new_alphabet
             self._alpha_len = len(self._alphabet)

--- a/shortuuid/main.py
+++ b/shortuuid/main.py
@@ -40,11 +40,11 @@ def string_to_int(string: str, alphabet: List[str]) -> int:
 
 
 class ShortUUID(object):
-    def __init__(self, alphabet: Optional[str] = None) -> None:
+    def __init__(self, alphabet: Optional[str] = None, should_sort: Optional[bool] = True) -> None:
         if alphabet is None:
             alphabet = "23456789ABCDEFGHJKLMNPQRSTUVWXYZ" "abcdefghijkmnopqrstuvwxyz"
 
-        self.set_alphabet(alphabet)
+        self.set_alphabet(alphabet, should_sort=should_sort)
 
     @property
     def _length(self) -> int:
@@ -110,11 +110,11 @@ class ShortUUID(object):
         """Return the current alphabet used for new UUIDs."""
         return "".join(self._alphabet)
 
-    def set_alphabet(self, alphabet: str) -> None:
+    def set_alphabet(self, alphabet: str, should_sort: bool=True) -> None:
         """Set the alphabet to be used for new UUIDs."""
         # Turn the alphabet into a set and sort it to prevent duplicates
         # and ensure reproducibility.
-        new_alphabet = list(sorted(set(alphabet)))
+        new_alphabet = list(sorted(set(alphabet)) if should_sort else list(dict.fromkeys(alphabet)))
         if len(new_alphabet) > 1:
             self._alphabet = new_alphabet
             self._alpha_len = len(self._alphabet)

--- a/shortuuid/test_shortuuid.py
+++ b/shortuuid/test_shortuuid.py
@@ -115,6 +115,29 @@ class ClassShortUUIDTest(unittest.TestCase):
         self.assertRaises(ValueError, su1.set_alphabet, "1")
         self.assertRaises(ValueError, su1.set_alphabet, "1111111")
 
+    def test_unsorted_alphabet(self):
+        alphabet = "123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ"
+
+        su1 = ShortUUID(alphabet, should_sort=False)
+        su2 = ShortUUID()
+
+        self.assertEqual(alphabet, su1.get_alphabet())
+
+        su2.set_alphabet(alphabet, should_sort=False)
+        self.assertEqual(alphabet, su2.get_alphabet())
+
+        su2.set_alphabet(alphabet + "123abc", should_sort=False)
+        self.assertEqual(alphabet, su2.get_alphabet())
+
+        u = uuid4()
+        self.assertEqual(u, su1.decode(su1.encode(u)))
+
+        u = su1.uuid()
+        self.assertEqual(u, su1.encode(su1.decode(u)))
+
+        self.assertRaises(ValueError, su1.set_alphabet, "1")
+        self.assertRaises(ValueError, su1.set_alphabet, "1111111")
+
     def test_encoded_length(self):
         su1 = ShortUUID()
         self.assertEqual(su1.encoded_length(), 22)

--- a/shortuuid/test_shortuuid.py
+++ b/shortuuid/test_shortuuid.py
@@ -118,15 +118,15 @@ class ClassShortUUIDTest(unittest.TestCase):
     def test_unsorted_alphabet(self):
         alphabet = "123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ"
 
-        su1 = ShortUUID(alphabet, should_sort=False)
+        su1 = ShortUUID(alphabet, dont_sort_alphabet=True)
         su2 = ShortUUID()
 
         self.assertEqual(alphabet, su1.get_alphabet())
 
-        su2.set_alphabet(alphabet, should_sort=False)
+        su2.set_alphabet(alphabet, dont_sort_alphabet=True)
         self.assertEqual(alphabet, su2.get_alphabet())
 
-        su2.set_alphabet(alphabet + "123abc", should_sort=False)
+        su2.set_alphabet(alphabet + "123abc", dont_sort_alphabet=True)
         self.assertEqual(alphabet, su2.get_alphabet())
 
         u = uuid4()


### PR DESCRIPTION
My attempt to fix: #104.

I've added `should_sort` kwarg to set_alphabet, whenever this is set to `False`, the code will use an ordered set rather than the default behaviour of sorting an unordered set.

Other than that, I've tried to integrate this behaviour into the Django Field. I don't have any experience working with custom Django fields, so I'd appreciate if someone could review commit 077ed4.