### PR TITLE
ci: Update workflows for GitHub Actions-supported Python versions and add 3.6+ compatibility check

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,8 +9,10 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
-    - uses: pre-commit/action@v3.0.0
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - uses: pre-commit/action@v3.0.1
       with:
         extra_args: -a --hook-stage=manual

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
-      with:
-        python-version: "3.12"
     - uses: pre-commit/action@v3.0.1
       with:
         extra_args: -a --hook-stage=manual

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,30 +6,13 @@ on:
     branches: [master]
 
 jobs:
-  # Verify code is compatible with Python 3.6 syntax
-  verify-compatibility:
-    name: Verify Python 3.6+ compatibility
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - name: Install vermin
-        run: pip install vermin
-      - name: Check minimum Python version
-        run: |
-          # Verify all source files are compatible with Python 3.6+
-          # --violations flag shows incompatible constructs
-          vermin --target=3.6 --violations shortuuid/
-
   test:
     name: Run tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
         # Test on currently supported Python versions
-        # Code compatibility with 3.6+ is verified via vermin above
+        # Code compatibility with 3.6+ is verified via vermin pre-commit hook
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,26 +6,39 @@ on:
     branches: [master]
 
 jobs:
+  # Verify code is compatible with Python 3.6 syntax
+  verify-compatibility:
+    name: Verify Python 3.6+ compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install vermin
+        run: pip install vermin
+      - name: Check minimum Python version
+        run: |
+          # Verify all source files are compatible with Python 3.6+
+          # --violations flag shows incompatible constructs
+          vermin --target=3.6 --violations shortuuid/
+
   test:
-    name: Run tests
+    name: Run tests (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        # Test on currently supported Python versions
+        # Python 3.7 is EOL and no longer available in GitHub Actions
+        # Code compatibility with 3.6+ is verified via vermin above
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: pip install pytest pytest-md pytest-emoji
+        run: pip install pytest
       - name: Run pytest
-        uses: pavelzw/pytest-action@v2
-        with:
-          verbose: true
-          emoji: true
-          job-summary: true
-          custom-arguments: '-q'
-          click-to-expand: true
-          report-title: 'Test Report'
+        run: pytest -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,12 +24,11 @@ jobs:
           vermin --target=3.6 --violations shortuuid/
 
   test:
-    name: Run tests (Python ${{ matrix.python-version }})
+    name: Run tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
         # Test on currently supported Python versions
-        # Python 3.7 is EOL and no longer available in GitHub Actions
         # Code compatibility with 3.6+ is verified via vermin above
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
@@ -39,6 +38,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: pip install pytest
+        run: pip install pytest pytest-md pytest-emoji
       - name: Run pytest
-        run: pytest -v
+        uses: pavelzw/pytest-action@v2
+        with:
+          verbose: true
+          emoji: true
+          job-summary: true
+          custom-arguments: '-q'
+          click-to-expand: true
+          report-title: 'Test Report'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,9 +15,15 @@ repos:
   hooks:
   - id: pydocstyle
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.991
+  rev: v1.14.1
   hooks:
   - id: mypy
+- repo: https://github.com/netromdk/vermin
+  rev: v1.8.0
+  hooks:
+  - id: vermin
+    name: Verify Python 3.6+ compatibility
+    args: ['-t=3.6-', '--violations']
 - repo: local
   hooks:
   - id: gitchangelog
@@ -26,4 +32,4 @@ repos:
     pass_filenames: false
     name: Generate changelog
     entry: bash -c "gitchangelog > CHANGELOG.md"
-    stages: [commit]
+    stages: [pre-commit]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,52 +7,130 @@
 
 * Allow compatibility with other ShortUUID libraries (#104) (#107) [Thiago Marinho]
 
-* Add the `encode` and `decode` commands to the cli. [Tim Crothers]
-
-* Add type hinting (#77) [Pablo Collado]
-
-* Add `prefix` and `max_length` to the Django field. [Stavros Korokithakis]
-
-* Add Django ShortUUIDField. [Stavros Korokithakis]
-
-* Added basic input type validation to encode and decode (#49) [Ivan Savov]
-
-* Drop support for Python before 3.5. [Stavros Korokithakis]
-
-* Add simple command-line interface (#43) [Éric Araujo]
-
-* Make int_to_string and string_to_int available globally. [Stavros Korokithakis]
-
 ### Fixes
 
 * Don't install COPYING at top level of wheel (#105) [Colin Watson]
 
+
+## v1.0.13 (2024-03-11)
+
+### Fixes
+
 * Improve randomness (#101) (#103) [hhartzer]
 
+
+## v1.0.12 (2024-02-28)
+
+### Fixes
+
 * Annotate *args as Any (#95) [Kamil Essekkat]
+
+
+## v1.0.10 (2022-11-09)
+
+### Features
+
+* Add the `encode` and `decode` commands to the cli. [Tim Crothers]
+
+* Add type hinting (#77) [Pablo Collado]
+
+### Fixes
 
 * Forgot to bump the version, oops. [Stavros Korokithakis]
 
 * Fix type annotations. [Stavros Korokithakis]
 
+
+## v1.0.9 (2022-05-08)
+
+### Fixes
+
 * Correctly account for length when prefix is used (fixes #71) [Stavros Korokithakis]
+
+
+## v1.0.8 (2021-11-11)
+
+### Fixes
 
 * Include the COPYING file in releases. [Stavros Korokithakis]
 
+
+## v1.0.7 (2021-11-08)
+
+### Features
+
+* Add `prefix` and `max_length` to the Django field. [Stavros Korokithakis]
+
+
+## v1.0.6 (2021-11-08)
+
+### Fixes
+
 * Fix compatibility for python versions older than 3.8 (#61) [Adrian Zuber]
+
+
+## v1.0.5 (2021-11-08)
+
+### Fixes
 
 * Don't try to get the version from the pyproject.toml, as it's a hassle. [Stavros Korokithakis]
 
 * Fix slow loading times from using pkg_resources (fixes #59) [Stavros Korokithakis]
 
+
+## v1.0.4 (2021-11-08)
+
+### Fixes
+
 * Fix the cli interface that the previous release broke. [Stavros Korokithakis]
+
+
+## v1.0.3 (2021-11-08)
+
+### Features
+
+* Add Django ShortUUIDField. [Stavros Korokithakis]
+
+
+## v1.0.2 (2021-11-08)
+
+### Features
+
+* Added basic input type validation to encode and decode (#49) [Ivan Savov]
+
+### Fixes
 
 * Use sys.version_info since sys.version returns string that interprets 3.10 as 3.1 in comparison. (#54) [Karthikeyan Singaravelan]
 
+
+## v1.0.1 (2020-03-06)
+
+### Features
+
+* Drop support for Python before 3.5. [Stavros Korokithakis]
+
+### Fixes
+
 * Use README as the long description on PyPI. [Stavros Korokithakis]
+
+
+## v1.0.0 (2020-03-05)
+
+### Features
+
+* Add simple command-line interface (#43) [Éric Araujo]
+
+### Fixes
 
 * Make encode and decode MSB-first (#36) [Keane Nguyen]
 
 * Make the URL check more robust (fixes #32) [Stavros Korokithakis]
+
+
+## v0.5.0 (2017-02-19)
+
+### Features
+
+* Make int_to_string and string_to_int available globally. [Stavros Korokithakis]
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,123 +3,56 @@
 
 ## Unreleased
 
-### Fixes
-
-* Improve randomness (#101) (#103) [hhartzer]
-
-
-## v1.0.12 (2024-02-28)
-
-### Fixes
-
-* Annotate *args as Any (#95) [Kamil Essekkat]
-
-
-## v1.0.10 (2022-11-09)
-
 ### Features
+
+* Allow compatibility with other ShortUUID libraries (#104) (#107) [Thiago Marinho]
 
 * Add the `encode` and `decode` commands to the cli. [Tim Crothers]
 
 * Add type hinting (#77) [Pablo Collado]
 
+* Add `prefix` and `max_length` to the Django field. [Stavros Korokithakis]
+
+* Add Django ShortUUIDField. [Stavros Korokithakis]
+
+* Added basic input type validation to encode and decode (#49) [Ivan Savov]
+
+* Drop support for Python before 3.5. [Stavros Korokithakis]
+
+* Add simple command-line interface (#43) [Éric Araujo]
+
+* Make int_to_string and string_to_int available globally. [Stavros Korokithakis]
+
 ### Fixes
+
+* Don't install COPYING at top level of wheel (#105) [Colin Watson]
+
+* Improve randomness (#101) (#103) [hhartzer]
+
+* Annotate *args as Any (#95) [Kamil Essekkat]
 
 * Forgot to bump the version, oops. [Stavros Korokithakis]
 
 * Fix type annotations. [Stavros Korokithakis]
 
-
-## v1.0.9 (2022-05-08)
-
-### Fixes
-
 * Correctly account for length when prefix is used (fixes #71) [Stavros Korokithakis]
-
-
-## v1.0.8 (2021-11-11)
-
-### Fixes
 
 * Include the COPYING file in releases. [Stavros Korokithakis]
 
-
-## v1.0.7 (2021-11-08)
-
-### Features
-
-* Add `prefix` and `max_length` to the Django field. [Stavros Korokithakis]
-
-
-## v1.0.6 (2021-11-08)
-
-### Fixes
-
 * Fix compatibility for python versions older than 3.8 (#61) [Adrian Zuber]
-
-
-## v1.0.5 (2021-11-08)
-
-### Fixes
 
 * Don't try to get the version from the pyproject.toml, as it's a hassle. [Stavros Korokithakis]
 
 * Fix slow loading times from using pkg_resources (fixes #59) [Stavros Korokithakis]
 
-
-## v1.0.4 (2021-11-08)
-
-### Fixes
-
 * Fix the cli interface that the previous release broke. [Stavros Korokithakis]
-
-
-## v1.0.3 (2021-11-08)
-
-### Features
-
-* Add Django ShortUUIDField. [Stavros Korokithakis]
-
-
-## v1.0.2 (2021-11-08)
-
-### Features
-
-* Added basic input type validation to encode and decode (#49) [Ivan Savov]
-
-### Fixes
 
 * Use sys.version_info since sys.version returns string that interprets 3.10 as 3.1 in comparison. (#54) [Karthikeyan Singaravelan]
 
-
-## v1.0.1 (2020-03-06)
-
-### Features
-
-* Drop support for Python before 3.5. [Stavros Korokithakis]
-
-### Fixes
-
 * Use README as the long description on PyPI. [Stavros Korokithakis]
-
-
-## v1.0.0 (2020-03-05)
-
-### Features
-
-* Add simple command-line interface (#43) [Éric Araujo]
-
-### Fixes
 
 * Make encode and decode MSB-first (#36) [Keane Nguyen]
 
 * Make the URL check more robust (fixes #32) [Stavros Korokithakis]
-
-
-## v0.5.0 (2017-02-19)
-
-### Features
-
-* Make int_to_string and string_to_int available globally. [Stavros Korokithakis]
 
 

--- a/shortuuid/django_fields.py
+++ b/shortuuid/django_fields.py
@@ -27,9 +27,9 @@ class ShortUUIDField(models.CharField):
 
     def _generate_uuid(self) -> str:
         """Generate a short random string."""
-        return self.prefix + ShortUUID(alphabet=self.alphabet, dont_sort_alphabet=self.dont_sort_alphabet).random(
-            length=self.length
-        )
+        return self.prefix + ShortUUID(
+            alphabet=self.alphabet, dont_sort_alphabet=self.dont_sort_alphabet
+        ).random(length=self.length)
 
     def deconstruct(self) -> Tuple[str, str, Tuple, Dict[str, Any]]:
         name, path, args, kwargs = super().deconstruct()

--- a/shortuuid/main.py
+++ b/shortuuid/main.py
@@ -40,7 +40,9 @@ def string_to_int(string: str, alphabet: List[str]) -> int:
 
 
 class ShortUUID(object):
-    def __init__(self, alphabet: Optional[str] = None, dont_sort_alphabet: Optional[bool] = False) -> None:
+    def __init__(
+        self, alphabet: Optional[str] = None, dont_sort_alphabet: bool = False
+    ) -> None:
         if alphabet is None:
             alphabet = "23456789ABCDEFGHJKLMNPQRSTUVWXYZ" "abcdefghijkmnopqrstuvwxyz"
 
@@ -110,11 +112,15 @@ class ShortUUID(object):
         """Return the current alphabet used for new UUIDs."""
         return "".join(self._alphabet)
 
-    def set_alphabet(self, alphabet: str, dont_sort_alphabet: bool=False) -> None:
+    def set_alphabet(self, alphabet: str, dont_sort_alphabet: bool = False) -> None:
         """Set the alphabet to be used for new UUIDs."""
         # Turn the alphabet into a set and sort it to prevent duplicates
         # and ensure reproducibility.
-        new_alphabet = list(dict.fromkeys(alphabet)) if dont_sort_alphabet else list(sorted(set(alphabet)))
+        new_alphabet = (
+            list(dict.fromkeys(alphabet))
+            if dont_sort_alphabet
+            else list(sorted(set(alphabet)))
+        )
         if len(new_alphabet) > 1:
             self._alphabet = new_alphabet
             self._alpha_len = len(self._alphabet)


### PR DESCRIPTION
## Summary

- CI/GitHub Actions compatibility updates:
  - Update test matrix from Python 3.7–3.9 to 3.8–3.14
  - Add `vermin` pre-commit hook to verify code remains compatible with Python 3.6+
  - Update `mypy` hook v0.991 → v1.14.1 (fixes Python 3.13+ compatibility)
  - Update Actions to v4/v5
  - Migrate pre-commit config to fix deprecated stage name
- Fixes for issues introduced in commit 6843c128, which was merged while CI was broken:
  - Fix type annotation bug in `ShortUUID.__init__` (`Optional[bool]` → `bool`)
  - Apply ruff-format to affected files

## Why this is needed

**Python 3.7 reached end-of-life**, and **GitHub Actions no longer supports it** on modern runners. This was causing all CI checks to fail. This PR updates the CI to test on currently supported Python versions and adds a [Vermin](https://github.com/netromdk/vermin) pre-commit hook to statically verify that the codebase remains compatible with Python 3.6+.

The old mypy hook (v0.991) required `typed_ast`, which isn't available on Python 3.13+, causing pre-commit to fail. Updated to v1.14.1 which supports Python 3.8–3.14.

## Fixes for 6843c128

Previous commit `6843c128` (PR #107) was merged on 2024-12-10, which happened to be 8 days after GitHub Actions removed support for Python 3.7, causing CI checks to break. This PR includes fixes for issues that would have been caught if CI had been working at the time.

**Timeline:**
- **2024-12-02**: Python 3.7 removal from GitHub Actions runners began ([actions/runner-images#10893](https://github.com/actions/runner-images/issues/10893))
- **2024-12-05**: PR #107 created; ubuntu-latest migration to Ubuntu 24.04 began ([actions/runner-images#10636](https://github.com/actions/runner-images/issues/10636))
- **2024-12-10**: PR #107 merged

**Verification commands:**
```console
$ gh api repos/skorokithakis/shortuuid/commits/6843c128/check-runs --jq '.check_runs[] | "\(.name): \(.conclusion)"'
Run tests (3.9): cancelled
Run tests (3.8): cancelled
Run tests (3.7): failure
pre-commit: failure
```

## Changes

- `.github/workflows/test.yml`: Update Python matrix, bump action versions
- `.github/workflows/pre-commit.yml`: Bump action versions
- `.pre-commit-config.yaml`: Add vermin hook, update mypy, migrate deprecated stage name
- `shortuuid/main.py`: Fix type annotation, apply ruff-format
- `shortuuid/django_fields.py`: Apply ruff-format

---

Generated with [Claude Code](https://claude.com/claude-code)
Steered and verified by @nikblanchet