### PR TITLE
Fix string_to_int radix when alphabet_index is provided

### DIFF
--- a/shortuuid/main.py
+++ b/shortuuid/main.py
@@ -45,7 +45,9 @@ def string_to_int(
     if alphabet_index is None:
         alphabet_index = {char: idx for idx, char in enumerate(alphabet)}
     number = 0
-    alpha_len = len(alphabet)
+    # Derive the radix from the index so `alphabet` is truly ignored when
+    # alphabet_index is passed, as documented above.
+    alpha_len = max(alphabet_index.values()) + 1
     for char in string:
         try:
             number = number * alpha_len + alphabet_index[char]

--- a/shortuuid/main.py
+++ b/shortuuid/main.py
@@ -47,7 +47,7 @@ def string_to_int(
     number = 0
     # Derive the radix from the index so `alphabet` is truly ignored when
     # alphabet_index is passed, as documented above.
-    alpha_len = max(alphabet_index.values()) + 1
+    alpha_len = len(alphabet_index)
     for char in string:
         try:
             number = number * alpha_len + alphabet_index[char]

--- a/shortuuid/test_shortuuid.py
+++ b/shortuuid/test_shortuuid.py
@@ -14,6 +14,7 @@ from shortuuid.main import get_alphabet
 from shortuuid.main import random
 from shortuuid.main import set_alphabet
 from shortuuid.main import ShortUUID
+from shortuuid.main import string_to_int
 from shortuuid.main import uuid
 
 sys.path.insert(0, os.path.abspath(__file__ + "/../.."))
@@ -220,6 +221,19 @@ class DecodingEdgeCasesTest(unittest.TestCase):
     def test_decode_invalid_characters(self):
         su = ShortUUID("abc")
         self.assertRaises(ValueError, su.decode, "xyz")
+
+    def test_string_to_int_ignores_alphabet_when_index_given(self):
+        # The docstring promises `alphabet` is ignored when `alphabet_index`
+        # is passed. Build an index for hex (base 16) while passing a decimal
+        # alphabet (len 10): the result must use base 16, not 10.
+        hex_index = {char: idx for idx, char in enumerate("0123456789abcdef")}
+        self.assertEqual(
+            string_to_int("10", alphabet="0123456789", alphabet_index=hex_index),
+            16,
+        )
+        # Correct usage (alphabet matches index) is unchanged.
+        self.assertEqual(string_to_int("10", alphabet="0123456789abcdef"), 16)
+        self.assertEqual(string_to_int("1f", alphabet="0123456789abcdef"), 31)
 
 
 class CliTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

`string_to_int` does not honour its own docstring: when an `alphabet_index` is supplied, the docstring states `alphabet` is ignored, but the implementation still uses `len(alphabet)` as the numeric base. If the caller passes an `alphabet_index` built from a different (longer) alphabet than the `alphabet` argument, the result is decoded in the wrong radix.

## Reproduction

```python
from shortuuid.main import string_to_int

hex_index = {c: i for i, c in enumerate("0123456789abcdef")}
# alphabet_index is base-16; per the docstring `alphabet` is ignored.
string_to_int("10", alphabet="0123456789", alphabet_index=hex_index)
# -> 10   (decoded base-10, because len("0123456789") == 10)
```

Expected `16` (the string `"10"` decoded base-16, per the supplied index). Correct usage where `alphabet` matches the index is unaffected:

```python
string_to_int("10", alphabet="0123456789abcdef")  # -> 16
string_to_int("1f", alphabet="0123456789abcdef")  # -> 31
```

## Cause

The docstring:

> The alphabet_index, if provided, should map each character to its index … If this is passed, `alphabet` is ignored.

But the base is taken from the `alphabet` argument regardless:

```python
alpha_len = len(alphabet)
```

So when `alphabet_index` is provided and `alphabet` is shorter than the index's true radix, the magnitude is wrong.

## Fix

Derive the radix from the supplied index instead:

```diff
     number = 0
-    alpha_len = len(alphabet)
+    alpha_len = max(alphabet_index.values()) + 1
     for char in string:
```

For any index built the documented way (`{char: idx for idx, char in enumerate(alphabet)}`), `max(values) + 1 == len(alphabet)`, so all existing behaviour is byte-for-byte unchanged. Only the mismatched case is corrected.

## Tests

Adds `test_string_to_int_ignores_alphabet_when_index_given`, which builds a base-16 index while passing a base-10 alphabet and asserts the result uses base 16. It fails on the current code (`10 != 16`) and passes with the fix. Full suite: 22 tests OK.

I couldn't find an existing issue or PR covering this — happy to fold it into one if I missed it.
