### PR TITLE
Fix Django field README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ class MyModel(models.Model):
         max_length=40,
         prefix="id_",
         alphabet="abcdefg1234",
-        dont_sort_alphabet=False
+        dont_sort_alphabet=False,
         primary_key=True,
     )
 


### PR DESCRIPTION
## Summary

Fixes the Django `ShortUUIDField` README example by adding the missing comma after `dont_sort_alphabet=False`.

Without the comma, the copied example is invalid Python because the following `primary_key=True` keyword argument is parsed as adjacent syntax.

## Validation

- Parsed the README Django snippet with `ast.parse` before the change and confirmed it failed with `SyntaxError: invalid syntax. Perhaps you forgot a comma?`
- Parsed the same README snippet after the change and confirmed it succeeds
- Ran `python -m pytest shortuuid` and confirmed `22 passed`